### PR TITLE
NearFuture Reactors Update

### DIFF
--- a/GameData/RealismOverhaul/RO_Resources.cfg
+++ b/GameData/RealismOverhaul/RO_Resources.cfg
@@ -285,10 +285,17 @@ RESOURCE_DEFINITION
 @RESOURCE_DEFINITION[DepletedUranium]:FOR[RealismOverhaul]
 {
   @unitCost = -1.097
+  @density = 0.001
+}
+@RESOURCE_DEFINITION[DepletedFuel]:FOR[RealismOverhaul]
+{
+  @unitCost = -1.097
+  @density = 0.001
 }
 @RESOURCE_DEFINITION[EnrichedUranium]:FOR[RealismOverhaul]
 {
   @unitCost = 54.85
+  @density = 0.001
 }
 @RESOURCE_DEFINITION[LeadBallast]:FOR[RealismOverhaul]
 {


### PR DESCRIPTION
**Please read issue 3 detailed near the bottom as it involves a potential issue with a lot of engines**

Fix to update Near Future reactor configs to work with update 1.2 

**Note 0**: Apologies for the amount of writing, however a lot of explanation and reasoning is required for this PR. 

**Note 1**: I am aware of work done such as by Schnobs, etc. however I have not seen any progress on the reactor configs in the past few months (years?) so I decided to have a stab at updating the configs. I have kept to as realistic values as possible, however certain estimations and changes have been made taking realism and balance into consideration. Feel free to critique and ask for changes, I aim to help RO first and foremost. Sources provided for all data, and reasoning for estimations where data is missing is also provided.

**Note 2**: I removed the 455 ton reactor and replaced it with a BES-5 Reactor (FYI flown 31 times, compared to 2 times for next most common reactor). I also added the TOPAZ-I in the 3.75m reactor slot (the aforementioned twice-flown reactor) which I believe gives a more realistic and useful lineup.

**Note 3**: Due to the strange way NF heat is handled, coupled with the fact that the mass quoted for most of the reactors includes the cooling systems, the required cooling has been kept to a value that is low enough to be believably realistic (and not look stupid with 50 large extendable radiators required), but high enough to require enough radiators to look and behave realistically. The exception is the SAFE 400, which based on its power-to-mass ratio should require a lot of added cooling.

**Changelog:**
- The modules have changed for NF Reactors, as a result the current patches don't patch much and stock stats are therefore used in-game. Applied fix to update to new modules (FissionReactor and FissionGenerator).

- Resource [DepletedUranium] is now referred to as [DepletedFuel] in NF. Applied fix for this change in RO_Resources.

- Module CoreHeat has been added for all reactors with correct stats.

- All descriptions were changed/updated, one contained a factually incorrect statement (the BES-5 was used on 31 missions, the Topaz-1 was used on 2 missions) and the others were brought more in line with other RO descriptions (include decade, etc.).

- The uranium barrels have had their masses and capacity changed to reflect more realistic and useful values(the 1.25m and 2.5m barrels were very close in stats). See issue 1 below.

- In real life, all of these reactors take 6-24hrs to heat up. A value of ~8hrs heat up has been applied across the board (without the addition of the GeneratorSpinupRate field which NF supports, the values are typically ~10-20mins so it is not too far fetched).

- Replaced 455-ton NuScale with BES-5 reactor.

- Added TOPAZ-I in place of the unused 3.75m reactor.

- Added a commented-out fix to resource definition to change mass of 1 unit Uranium from 11kg to 1kg. See issue 3 below.

- Reduced electric charge storage to more realistic levels, scaled to mass. Although storage should probably be removed for full realism as that is what proc batteries are for. Reduced to 1MJ/ton for now.

- Full source and basic part information provided as comments for all 5 reactors in config file.

- The FissionReactor modules are first deleted before being re-added due to issues with altering the input and output resource ratios, not due to inefficiency.

- The order that the reactors appear in the tech tree has been changed to a more logical order with the 2 new additions.

- Nuclear Reprocessor has been changed to WIP as I haven't looked at updating it to work with 1.2 yet, although it is clear that it currently does not work correctly.

- B9PartSwitch modules fixed for BES-5 and SAFE 400 as they removed nodes by default (bottom and top respectively).

**Issues**

1) All of these reactors are designed in real life for either single use, or in the case of the RAPID-L (and maybe the SAFE 400) two uses at most. In other words, you shouldn't be able to just turn on and off the reactor as you please. One possible route is to use ModuleGenerator with the ability to shut down once started removed, similar to an SRB. Ideally I'd remove the barrels also, or else make them specific to the Rapid-L and SAFE 400 designs. However I have left them for now, with the disincentive of taking 8 hours to heat up to try to negate this behaviour.

2) In order to tweak the heat generated to levels low enough for an appropriate number of radiators, it shows up a relatively arbitrary number for the cooling required/heat generated as a result. This can't be fixed unless ChrisAdderley changes NFE to accommodate this somehow (which is quite an ask for a superficial issue), but for now arbitrary numbers in the display will have to stay.

3) The mass of 1 unit of uranium is currently set to 11kg and I'm not sure why? I have examined the other places that the resource EnrichedUranium is used, and it only appears to be for the engines such as NERVA I and II, Atomic Age, Bimodal, Laztek, Novapunch, and CMES nuclear engines. In each case, changing the mass from 11kg to 1kg does not break anything immediately (consumption of kg/s goes down, but the actual consumption in units/s will stay the same i.e. fuel will last just as long as before) although the ratios for those parts might have to be revisited if they are written for a density of 11kg. I've left the fix in for now and will edit based on what the consensus is about changing the density, although if changing this value causes an issue please point it out. Just making sure that people are aware the NERVA II carries 165kg of Uranium and not 15kg for example. The fix to density should probably happen in RO_Resources.cfg if it is approved (my bad, just wanted to get it out there first). It makes more sense to have 1 unit = 1kg. 

4) Using the stock NFE models isn't quite aesthetically appropriate but I do not have the time to model them myself plus very little data exists on the appearance of the SAFE 400, etc. The 2 new reactors have been sized appropriately from NFE models however.

5) The TOPAZ-I fuel consumption is below the minimum threshold coded by ChrisAdderley, and therefore it will always show that the reactor has a "very long" time left. Again, no fix for this from my side. However it should still be clear from the part description and the current fuel level what the situation is at any time so this issue can be ignored.

**Future Work**

1) Adding more reactors including the SNAP-10A, KiloPower 1kWe to 10kWe series, SAFE 30, SAFE 300, etc.

2) Update Nuclear Reprocessor to the same standard.
